### PR TITLE
Add support for card param for authorize

### DIFF
--- a/lib/datatrans/json/transaction/authorize.rb
+++ b/lib/datatrans/json/transaction/authorize.rb
@@ -27,7 +27,7 @@ class Datatrans::JSON::Transaction
     def request_body
       auto_settle = params[:auto_settle].nil? ? true : params[:auto_settle]
 
-      {
+      body = {
         "currency": params[:currency],
         "refno": params[:refno],
         "amount": params[:amount],
@@ -39,6 +39,10 @@ class Datatrans::JSON::Transaction
           "errorUrl": params[:error_url]
         }
       }
+
+      body["card"] = params[:card] if params[:card]
+
+      body
     end
   end
 

--- a/spec/json/authorize_spec.rb
+++ b/spec/json/authorize_spec.rb
@@ -71,6 +71,22 @@ describe Datatrans::JSON::Transaction::Authorize do
     end
   end
 
+  context "with card provided" do
+    it "uses card in request_body" do
+      card_params = {
+        "alias": "AAABcH0Bq92s3kgAESIAAbGj5NIsAHWC",
+        "expiryMonth": "06",
+        "expiryYear": "25"
+      }
+
+      params_with_auto_settle = @valid_params.merge(card: card_params)
+      request = Datatrans::JSON::Transaction::Authorize.new(@datatrans, params_with_auto_settle)
+
+      expected_request_body_with_card = @expected_request_body.merge("card" => card_params)
+      expect(request.request_body).to eq(expected_request_body_with_card)
+    end
+  end
+
   context "failed response" do
     before do
       allow_any_instance_of(Datatrans::JSON::Transaction::Authorize).to receive(:process).and_return(@failed_response)


### PR DESCRIPTION
To create a transaction without user interaction, an `alias` can be used. For merchant-initiated transactions with an existing `alias`, the `card` object is expected by the authorize endpoint.

See: https://api-reference.datatrans.ch/#tag/v1transactions/operation/authorize